### PR TITLE
add custom icon ability

### DIFF
--- a/src/components/atoms/Icon/FowIcons/icons/Logo.ts
+++ b/src/components/atoms/Icon/FowIcons/icons/Logo.ts
@@ -1,0 +1,19 @@
+import {
+    IconDefinition,
+    IconName,
+    IconPrefix,
+} from '@fortawesome/fontawesome-common-types';
+
+const fowLogo: IconDefinition = {
+    prefix: 'fas' as IconPrefix,
+    iconName: 'fow-logo' as IconName,
+    icon: [
+        6, // viewbox width
+        15, // viewbox height
+        [],
+        'f0001', // increase one for other icons
+        'M1.63468 14.9899V9.17236H0V7.12034H1.63468V3.27303C1.63468 1.10818 2.81429 0 4.51388 0C5.02368 0.00387811 5.5281 0.11535 6 0.328416L5.72138 2.27743C5.38116 2.1433 5.02361 2.07051 4.66245 2.06185C4.05882 2.06185 3.58453 2.36956 3.58453 3.36491V7.13043H3.59391V9.18245H3.58524V15H1.63468V14.9899Z', // single line svg path
+    ],
+};
+
+export default fowLogo;

--- a/src/components/atoms/Icon/FowIcons/index.ts
+++ b/src/components/atoms/Icon/FowIcons/index.ts
@@ -1,0 +1,3 @@
+import Logo from './icons/Logo';
+
+export default { Logo };

--- a/src/components/atoms/Icon/Icon.stories.tsx
+++ b/src/components/atoms/Icon/Icon.stories.tsx
@@ -2,12 +2,15 @@ import React from 'react';
 import { Story, Meta } from '@storybook/react';
 import { FontAwesomeIconProps } from '@fortawesome/react-fontawesome';
 import * as Icons from '@fortawesome/free-solid-svg-icons';
+import FowIcons from './FowIcons';
 
 import Icon from './Icon';
 
-const iconList = Object.keys(Icons)
+const AllIcons = { ...Icons, ...FowIcons };
+
+const iconList = Object.keys(AllIcons)
     .filter((key) => key !== 'fas' && key !== 'prefix')
-    .map((icon) => Icons[icon]);
+    .map((icon) => AllIcons[icon]);
 
 export default {
     title: 'Atoms/Icon',
@@ -26,6 +29,7 @@ const Template: Story<FontAwesomeIconProps> = (args) => <Icon {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {
-    icon: ['far','comment'],
+    icon: 'fow-logo',
     color: 'black',
+    size: '1x',
 };

--- a/src/components/atoms/Icon/Icon.tsx
+++ b/src/components/atoms/Icon/Icon.tsx
@@ -7,11 +7,20 @@ import {
 import { library } from '@fortawesome/fontawesome-svg-core';
 import { fas } from '@fortawesome/free-solid-svg-icons';
 import { far } from '@fortawesome/free-regular-svg-icons';
+import FowIcons from './FowIcons';
 
 library.add(far, fas);
+library.add(FowIcons);
 
-const Icon = ({ icon, ...rest }: FontAwesomeIconProps): JSX.Element => (
-    <FontAwesomeIcon icon={icon} {...rest} />
+type FowIconsType = 'fow-logo';
+// @ts-ignore
+export interface IconProps extends FontAwesomeIconProps {
+    icon: FontAwesomeIconProps['icon'] | FowIconsType;
+}
+
+const Icon = ({ icon, ...rest }: IconProps): JSX.Element => (
+    // @ts-ignore
+    <FontAwesomeIcon icon={icon} fixedWidth {...rest} />
 );
 
 export default Icon;


### PR DESCRIPTION
define icons in FowIcons>Icons 
example defination: 
```
const fowLogo: IconDefinition = {
    prefix: 'fas' as IconPrefix,
    iconName: 'fow-logo' as IconName,
    icon: [
        6, // viewbox width
        15, // viewbox height
        [],
        'f0001', // increase one for other icons
        'M1.63468 14.9899V9.17236H0V7.12034H1.63468V3.27303C1.63468 1.10818 2.81429 0 4.51388 0C5.02368 0.00387811 5.5281 0.11535 6 0.328416L5.72138 2.27743C5.38116 2.1433 5.02361 2.07051 4.66245 2.06185C4.05882 2.06185 3.58453 2.36956 3.58453 3.36491V7.13043H3.59391V9.18245H3.58524V15H1.63468V14.9899Z', // single line svg path
    ],
};
```

for typing add icon name manually to FowIconType in Icon.tsx

```type FowIconsType = 'fow-logo' | 'fow-opportunity' .... ;```

for usage as is now

```<Icon icon="fow-logo" />```